### PR TITLE
Fix: get request no longer exposes DB id

### DIFF
--- a/controller/person.controller.js
+++ b/controller/person.controller.js
@@ -2,8 +2,8 @@ const Person = require('../model/person.model');
 
 async function getRandomPerson (ctx) {
   try {
-    // get one Person documment  randomly.
-    const [person] = await Person.aggregate().sample(1);
+    // get one Person documment randomly. Projection removes db id, so it's not exposed.
+    const [person] = await Person.aggregate().sample(1).project('-_id');
     if (person) ctx.body = person;
     else ctx.status = 500;
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node index.js"
+    "start": "node index.js",
+    "dev": "nodemon index.js"
   },
   "engines": {
     "node": "14.8.0"


### PR DESCRIPTION
When returning a person document, return all fields except the _id field.